### PR TITLE
Add GAI chatbot embed with scripts moved to body for proper rendering

### DIFF
--- a/ChatbotAI/AGbot.html
+++ b/ChatbotAI/AGbot.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+</head>
+
+<body>
+  <h1>GAI Bot Loaded</h1>
+  <script src="https://cdn.botpress.cloud/webchat/v3.0/inject.js"></script>
+  <script src="https://files.bpcontent.cloud/2025/07/02/19/20250702190802-IGYRJ6W4.js"></script>
+</body>
+
+</html>

--- a/ChatbotAI/AGbot.html
+++ b/ChatbotAI/AGbot.html
@@ -2,6 +2,8 @@
 <html>
 
 <head>
+  <!-- Botpress scripts moved to body for correct loading -->
+
 </head>
 
 <body>


### PR DESCRIPTION
This PR adds the GAI chatbot to the frontend using the official Botpress Webchat integration.

No manual setup needed — just open the HTML and the bot will load automatically.

Tested on Chrome, Firefox, and Edge  
No console errors  
Loads on page open  
